### PR TITLE
Implement basic refract functionality based on configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.refract = require('./lib/refract.js');
+module.exports = require('./lib/refract.js');

--- a/lib/refract.js
+++ b/lib/refract.js
@@ -75,3 +75,4 @@ function refract(src, method) {
         (yield instance)[method](req, res, next);
     });
 }
+module.exports = refract;

--- a/lib/refract.js
+++ b/lib/refract.js
@@ -1,2 +1,77 @@
 "use strict";
-console.log("hello world");
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+let dir;
+let config = (() => {
+    const packageName = require('../package.json').name;
+    // Get the current working directory
+    dir = process.cwd();
+    for (;;) {
+        // If the current working directory has a package.json, break
+        if (fs.statSync(path.join(dir, 'package.json')).isFile())
+            break;
+        // eslint-disable-next-line no-empty
+        // Otherwise, keep looking for it
+        const parent = path.dirname(dir);
+        if (dir === parent) {
+            dir = null;
+            break;
+        }
+        dir = parent;
+    }
+    // Once the current directory has been found, load the configuration file
+    try {
+        return require(path.resolve(dir, 'refractile.config.js'));
+    }
+    catch (e) {
+        throw Error('Error: problem loading refractile.config.js -- ' + e);
+    }
+})();
+function refract(src, method) {
+    let instance;
+    if (typeof src === 'string') {
+        // 1.0 look up configuration
+        if (!config[src])
+            throw Error('No configuration found for module ' +
+                src +
+                '. Check configuration at ' +
+                dir);
+        // 2.0 check module destination location
+        if (!config[src]['bin'])
+            throw Error('No bin destination found for module ' +
+                '. Check configuration at ' +
+                dir);
+        // If there is no file in bin, try to make it
+        if (!fs.statSync(path.resolve(config[src]['bin'], `${src}.js`)).isFile()) {
+            if (!config[src]['make'])
+                throw Error('No make formula found for module ' +
+                    '. Check configuration at ' +
+                    dir);
+            // Build it
+            execSync(config[src]['make']);
+            // Check that it was made
+            if (!fs.statSync(path.resolve(config[src]['bin'], `${src}.js`)).isFile())
+                throw Error('Failed to build ' + src);
+        }
+        // Load it
+        instance = require(path.resolve(config[src]['bin'], `${src}.js`))();
+    }
+    else if (typeof src === 'function') {
+        // 2.0 load the instance from the function
+        instance = src();
+    }
+    return (req, res, next) => __awaiter(this, void 0, void 0, function* () {
+        (yield instance)[method](req, res, next);
+    });
+}

--- a/lib/refract.js
+++ b/lib/refract.js
@@ -13,7 +13,9 @@ const path = require('path');
 const fs = require('fs');
 const { execSync } = require('child_process');
 let dir;
-let config = (() => {
+let config;
+// Load config
+(() => {
     const packageName = require('../package.json').name;
     // Get the current working directory
     dir = process.cwd();
@@ -32,40 +34,49 @@ let config = (() => {
     }
     // Once the current directory has been found, load the configuration file
     try {
-        return require(path.resolve(dir, 'refractile.config.js'));
+        config = require(path.resolve(dir, 'refractile.config.js'));
     }
     catch (e) {
         throw Error('Error: problem loading refractile.config.js -- ' + e);
     }
+    if (Array.isArray(config['preload_cmds']))
+        config['preload_cmds'].forEach((cmd) => {
+            try {
+                execSync(cmd);
+            }
+            catch (e) {
+                throw Error('Error: problem running preload_cmd: ' + cmd);
+            }
+        });
 })();
 function refract(src, method) {
     let instance;
     if (typeof src === 'string') {
         // 1.0 look up configuration
-        if (!config[src])
+        if (!config.modules || !config.modules[src])
             throw Error('No configuration found for module ' +
                 src +
                 '. Check configuration at ' +
                 dir);
         // 2.0 check module destination location
-        if (!config[src]['bin'])
+        if (!config.modules[src]['bin'])
             throw Error('No bin destination found for module ' +
                 '. Check configuration at ' +
                 dir);
         // If there is no file in bin, try to make it
-        if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`))) {
-            if (!config[src]['make'])
+        if (!fs.existsSync(path.resolve(config.modules[src]['bin'], `${src}.js`))) {
+            if (!config.modules[src]['make'])
                 throw Error('No make formula found for module ' +
                     '. Check configuration at ' +
                     dir);
             // Build it
-            execSync(config[src]['make']);
+            execSync(config.modules[src]['make']);
             // Check that it was made
-            if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`)))
+            if (!fs.existsSync(path.resolve(config.modules[src]['bin'], `${src}.js`)))
                 throw Error('Failed to build ' + src);
         }
         // Load it
-        instance = require(path.resolve(config[src]['bin'], `${src}.js`))();
+        instance = require(path.resolve(config.modules[src]['bin'], `${src}.js`))();
     }
     else if (typeof src === 'function') {
         // 2.0 load the instance from the function

--- a/lib/refract.js
+++ b/lib/refract.js
@@ -53,7 +53,7 @@ function refract(src, method) {
                 '. Check configuration at ' +
                 dir);
         // If there is no file in bin, try to make it
-        if (!fs.statSync(path.resolve(config[src]['bin'], `${src}.js`)).isFile()) {
+        if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`))) {
             if (!config[src]['make'])
                 throw Error('No make formula found for module ' +
                     '. Check configuration at ' +
@@ -61,7 +61,7 @@ function refract(src, method) {
             // Build it
             execSync(config[src]['make']);
             // Check that it was made
-            if (!fs.statSync(path.resolve(config[src]['bin'], `${src}.js`)).isFile())
+            if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`)))
                 throw Error('Failed to build ' + src);
         }
         // Load it

--- a/lib/refract.ts
+++ b/lib/refract.ts
@@ -93,3 +93,5 @@ function refract(
     (await instance)[method](req, res, next);
   };
 }
+
+module.exports = refract;

--- a/lib/refract.ts
+++ b/lib/refract.ts
@@ -9,7 +9,10 @@ type RefractileConfigModule = {
 };
 
 type RefractileConfig = {
-  [module: string]: RefractileConfigModule;
+  preload_cmds: Array<string>;
+  modules: {
+    [module: string]: RefractileConfigModule;
+  };
 };
 
 type ExpressMWare = (req: Request, res: Response, next: NextFunction) => void;
@@ -18,7 +21,10 @@ type RefractInstance = {
 };
 
 let dir: string | null;
-let config: RefractileConfig = (() => {
+let config: RefractileConfig;
+
+// Load config
+(() => {
   const packageName = require('../package.json').name;
   // Get the current working directory
 
@@ -38,11 +44,21 @@ let config: RefractileConfig = (() => {
 
   // Once the current directory has been found, load the configuration file
   try {
-    return require(path.resolve(dir, 'refractile.config.js'));
+    config = require(path.resolve(dir, 'refractile.config.js'));
   } catch (e) {
     throw Error('Error: problem loading refractile.config.js -- ' + e);
   }
+
+  if (Array.isArray(config['preload_cmds']))
+    config['preload_cmds'].forEach((cmd) => {
+      try {
+        execSync(cmd);
+      } catch (e) {
+        throw Error('Error: problem running preload_cmd: ' + cmd);
+      }
+    });
 })();
+
 function refract(
   src: string | (() => Promise<RefractInstance>),
   method: string
@@ -50,7 +66,7 @@ function refract(
   let instance: Promise<RefractInstance>;
   if (typeof src === 'string') {
     // 1.0 look up configuration
-    if (!config[src])
+    if (!config.modules || !config.modules[src])
       throw Error(
         'No configuration found for module ' +
           src +
@@ -58,7 +74,7 @@ function refract(
           dir
       );
     // 2.0 check module destination location
-    if (!config[src]['bin'])
+    if (!config.modules[src]['bin'])
       throw Error(
         'No bin destination found for module ' +
           '. Check configuration at ' +
@@ -66,8 +82,8 @@ function refract(
       );
 
     // If there is no file in bin, try to make it
-    if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`))) {
-      if (!config[src]['make'])
+    if (!fs.existsSync(path.resolve(config.modules[src]['bin'], `${src}.js`))) {
+      if (!config.modules[src]['make'])
         throw Error(
           'No make formula found for module ' +
             '. Check configuration at ' +
@@ -75,15 +91,15 @@ function refract(
         );
 
       // Build it
-      execSync(config[src]['make']);
+      execSync(config.modules[src]['make']);
 
       // Check that it was made
-      if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`)))
+      if (!fs.existsSync(path.resolve(config.modules[src]['bin'], `${src}.js`)))
         throw Error('Failed to build ' + src);
     }
 
     // Load it
-    instance = require(path.resolve(config[src]['bin'], `${src}.js`))();
+    instance = require(path.resolve(config.modules[src]['bin'], `${src}.js`))();
   } else if (typeof src === 'function') {
     // 2.0 load the instance from the function
     instance = src();

--- a/lib/refract.ts
+++ b/lib/refract.ts
@@ -66,7 +66,7 @@ function refract(
       );
 
     // If there is no file in bin, try to make it
-    if (!fs.statSync(path.resolve(config[src]['bin'], `${src}.js`)).isFile()) {
+    if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`))) {
       if (!config[src]['make'])
         throw Error(
           'No make formula found for module ' +
@@ -78,7 +78,7 @@ function refract(
       execSync(config[src]['make']);
 
       // Check that it was made
-      if (!fs.statSync(path.resolve(config[src]['bin'], `${src}.js`)).isFile())
+      if (!fs.existsSync(path.resolve(config[src]['bin'], `${src}.js`)))
         throw Error('Failed to build ' + src);
     }
 


### PR DESCRIPTION
Implements a configuration system based on the following format:
```
{ 
preload_cmds: ["echo $PWD"] /* an array of commands to run when the config is loaded */
modules: { /* an object containing individual modules's configurations */
        example: { 
                bin: "path/to/bin",
                make: "emcc some-folder/some-file.cpp -o path/to/src/bin/some-module.js -Os --bind"
        }
    }
}
```

- It is not yet sensitive to updates to code (i.e. some kind of intelligent recompilation)
- Is only able to look for JS glue code at the moment, and doesn't support directly loading .wasm into glue code
- requires further testing
